### PR TITLE
修复获取昵称问题

### DIFF
--- a/nonebot_plugin_fakepic/__main__.py
+++ b/nonebot_plugin_fakepic/__main__.py
@@ -33,14 +33,14 @@ class User:
 async def get_user_name(user_id: int) -> str:
     bot = current_bot.get()
     try:
-        nick = (await bot.get_stranger_info(user_id=user_id))['nick']
+        nick = (await bot.get_stranger_info(user_id=user_id))['nickname']
     except Exception as e:
         logger.error(e)
         try:
             async with AsyncClient() as client:
-                res = await client.get(f"https://api.usuuu.com/qq/{user_id}")
+                res = await client.get(f"https://api.leafone.cn/api/qqnick?qq={user_id}")
                 data = res.json()
-                nick = data.get("data").get("name")
+                nick = data.get("data").get("nickname")
         except Exception as e:
             logger.error(e)
             nick = "QQ用户"


### PR DESCRIPTION
修复onebot11标准方法
更换API，免费接口请求QPS为 10 秒 1 次，可登录获取apiKey高频使用，地址https://api.leafone.cn/doc/qqnick.html